### PR TITLE
Bump mypy from 0.761 to 0.770 (#1536)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
   - id: flake8
     additional_dependencies: ['flake8-bugbear==20.1.0']
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.761
+  rev: v0.770
   hooks:
   - id: mypy
 - repo: https://github.com/asottile/blacken-docs

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 EXTRAS_REQUIRE = {
     "tests": ["pytest", "pytz", "simplejson"],
     "lint": [
-        "mypy==0.761",
+        "mypy==0.770",
         "flake8==3.7.9",
         "flake8-bugbear==20.1.4",
         "pre-commit>=1.20,<3.0",

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -1040,10 +1040,8 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
             # Field declared as a class, not an instance. Ignore type checking because
             # we handle unsupported arg types, i.e. this is dead code from
             # the type checker's perspective.
-            if isinstance(field_obj, type) and issubclass(  # type: ignore
-                field_obj, base.FieldABC
-            ):
-                msg = (  # type: ignore
+            if isinstance(field_obj, type) and issubclass(field_obj, base.FieldABC):
+                msg = (
                     'Field for "{}" must be declared as a '
                     "Field instance, not a class. "
                     'Did you mean "fields.{}()"?'.format(field_name, field_obj.__name__)


### PR DESCRIPTION
* Bump mypy from 0.761 to 0.770

Bumps [mypy](https://github.com/python/mypy) from 0.761 to 0.770.
- [Release notes](https://github.com/python/mypy/releases)
- [Commits](https://github.com/python/mypy/compare/v0.761...v0.770)

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>

* Update mypy in pre-commit

* Remove unused type: ignore comments

Co-authored-by: dependabot-preview[bot] <27856297+dependabot-preview[bot]@users.noreply.github.com>
Co-authored-by: Steven Loria <sloria1@gmail.com>